### PR TITLE
Add environment variable and docs to allow skip TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ func main() {
 	log.Println("Message Sent!")
 }
 ```
+## Configuration option
+
+If needed, you can disable SSL handcheck validation using an environment variable:
+```
+export GOTIFY_SKIP_TLS=True
+```
 
 ## Update Instructions
 

--- a/gotify/factory.go
+++ b/gotify/factory.go
@@ -1,13 +1,24 @@
 package gotify
 
 import (
-	"net/url"
+	"crypto/tls"
 	"net/http"
-	api "github.com/gotify/go-api-client/v2/client"
+	"net/url"
+	"os"
+
 	httptransport "github.com/go-openapi/runtime/client"
+	api "github.com/gotify/go-api-client/v2/client"
 )
 
+var GOTIFY_SKIP_TLS = "GOTIFY_SKIP_TLS"
+
 func NewClient(url *url.URL, client *http.Client) *api.GotifyREST {
+	should_skip_tls := os.Getenv(GOTIFY_SKIP_TLS) == "True"
+
+	if should_skip_tls {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
 	runtime := httptransport.NewWithClient(url.Host, url.Path, []string{url.Scheme}, client)
 	return api.New(runtime, nil)
 }


### PR DESCRIPTION
Adding a rather explicit option to ignore SSL validation, this is required in case of self signed x509s, also raised in https://github.com/gotify/cli/issues/27

